### PR TITLE
feat: add parameter `containerName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Azure Resource Manager (ARM) template that creates an Azure Storage account to s
 
 - Creates a storage account with the specified name.
 - Configures the storage account according to [security recommendations](https://learn.microsoft.com/en-us/azure/storage/blobs/security-recommendations).
-- Creates a storage container `tfstate`.
+- Creates a blob container with the specified name.
 - Grants access to the storage account for specified user, group and service principals.
 - Creates a read-only lock to prevent changes to the storage account.
 
@@ -83,6 +83,7 @@ Azure Resource Manager (ARM) template that creates an Azure Storage account to s
 | Name | Description | Type | Default |
 | - | - | - | - |
 | `storageAccountName` | The name of the storage account to create. | `string` | |
+| `containerName` | The name of the blob container to create. | `string` | `tfstate` |
 | `ipRules` | An array of IP addresses or ranges that should be granted access to the storage account. If empty, all IP addresses and ranges will be granted access to the storage account. | `array` | `[]` |
 | `principalIds` | An array of object IDs for user, group or service principals that should be granted access to the storage account. | `array` | `[]` |
 
@@ -91,7 +92,7 @@ Azure Resource Manager (ARM) template that creates an Azure Storage account to s
 | Name | Description | Type |
 | - | - | - |
 | `storageAccountName` | The name of the storage account that was created. | `string` |
-| `containerName` | The name of the storage container that was created. | `string` |
+| `containerName` | The name of the blob container that was created. | `string` |
 
 ## References
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.32.4.45862",
-      "templateHash": "6435624962667709005"
+      "templateHash": "8688306575345230913"
     }
   },
   "parameters": {
@@ -13,6 +13,12 @@
       "type": "string",
       "metadata": {
         "description": "The name of the Storage account to create."
+      }
+    },
+    "containerName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the blob container to create."
       }
     },
     "ipRules": {
@@ -34,7 +40,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
       "apiVersion": "2023-05-01",
-      "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), 'default', 'tfstate')]",
+      "name": "[format('{0}/{1}/{2}', parameters('storageAccountName'), 'default', parameters('containerName'))]",
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('storageAccountName'), 'default')]"
       ]
@@ -172,9 +178,9 @@
     "containerName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the Storage container that was created."
+        "description": "The name of the blob container that was created."
       },
-      "value": "tfstate"
+      "value": "[parameters('containerName')]"
     }
   }
 }

--- a/main.bicep
+++ b/main.bicep
@@ -1,6 +1,9 @@
 @description('The name of the Storage account to create.')
 param storageAccountName string
 
+@description('The name of the blob container to create.')
+param containerName string
+
 @description('An array of IP addresses or IP ranges that should be allowed to bypass the firewall of the Terraform backend. If empty, the firewall will be disabled.')
 param ipRules array = []
 
@@ -52,7 +55,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
     }
 
     resource container 'containers' = {
-      name: 'tfstate'
+      name: containerName
     }
   }
 
@@ -115,5 +118,5 @@ resource lock 'Microsoft.Authorization/locks@2020-05-01' = {
 @description('The name of the Storage account that was created.')
 output storageAccountName string = storageAccount.name
 
-@description('The name of the Storage container that was created.')
+@description('The name of the blob container that was created.')
 output containerName string = storageAccount::blobService::container.name


### PR DESCRIPTION
Create blob container with the specified name. Set previously hard coded value as default to ensure backwards compatability.