### PR TITLE
fix: add default value for parameter `containerName`

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.32.4.45862",
-      "templateHash": "8688306575345230913"
+      "templateHash": "16091004168660921865"
     }
   },
   "parameters": {
@@ -17,6 +17,7 @@
     },
     "containerName": {
       "type": "string",
+      "defaultValue": "tfstate",
       "metadata": {
         "description": "The name of the blob container to create."
       }

--- a/main.bicep
+++ b/main.bicep
@@ -2,7 +2,7 @@
 param storageAccountName string
 
 @description('The name of the blob container to create.')
-param containerName string
+param containerName string = 'tfstate'
 
 @description('An array of IP addresses or IP ranges that should be allowed to bypass the firewall of the Terraform backend. If empty, the firewall will be disabled.')
 param ipRules array = []


### PR DESCRIPTION
Forgot to add default value `tfstate` in commit 137ef2a1d40fbacc94f6cd5d02ecb1b614646f30, breaking compatability with previous versions of the template where value `tfstate` was hard coded.