### PR TITLE
docs: simplify usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,7 @@ Azure Resource Manager (ARM) template that creates an Azure Storage account to s
 
    Requires Azure role `Contributor` at subscription.
 
-1. Create a deployment at resource group from the template file:
-
-   ```console
-   az deployment group create --name terraform-backend --resource-group <RESOURCE_GROUP_NAME> --template-file azuredeploy.json --parameters storageAccountName=<STORAGE_ACCOUNT_NAME>
-   ```
-
-   Alternatively, create a deployment at resource group from the template URI:
+1. Create a deployment at resource group from the template URI:
 
    ```console
    az deployment group create --name terraform-backend --resource-group <RESOURCE_GROUP_NAME> --template-uri https://raw.githubusercontent.com/equinor/azure-terraform-backend-template/refs/heads/main/azuredeploy.json --parameters storageAccountName=<STORAGE_ACCOUNT_NAME>


### PR DESCRIPTION
Usage section should be as simple and concise as possible. Remove instructions for creating deployment from template file, and keep instructions for creating deployment from template URI. Creating a deployment from template URI can be done without cloning this repository or copying the contents of the template file.
