### PR TITLE
feat: add parameter `allowSharedAccessKey`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ Azure Resource Manager (ARM) template that creates an Azure Storage account to s
 | - | - | - | - |
 | `storageAccountName` | The name of the storage account to create. | `string` | |
 | `containerName` | The name of the blob container to create. | `string` | `tfstate` |
+| `allowSharedAccessKey` | Allow authenticating to the storage account using a shared access key? | `bool` | `false` |
 | `ipRules` | An array of IP addresses or ranges that should be granted access to the storage account. If empty, all IP addresses and ranges will be granted access to the storage account. | `array` | `[]` |
-| `principalIds` | An array of object IDs for user, group or service principals that should be granted access to the storage account. | `array` | `[]` |
+| `principalIds` | An array of object IDs for user, group or service principals that should be allowed to authenticate to the storage account using Microsoft Entra. | `array` | `[]` |
 
 > [!TIP]
 > Rather than passing parameters as inline values, create a [parameter file](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/parameter-files).

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.32.4.45862",
-      "templateHash": "16091004168660921865"
+      "version": "0.33.93.31351",
+      "templateHash": "1377408791130358480"
     }
   },
   "parameters": {
@@ -20,6 +20,13 @@
       "defaultValue": "tfstate",
       "metadata": {
         "description": "The name of the blob container to create."
+      }
+    },
+    "allowSharedKeyAccess": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Allow authenticating to the storage account using a shared access key?"
       }
     },
     "ipRules": {
@@ -116,7 +123,7 @@
         "supportsHttpsTrafficOnly": true,
         "minimumTlsVersion": "TLS1_2",
         "allowBlobPublicAccess": false,
-        "allowSharedKeyAccess": false,
+        "allowSharedKeyAccess": "[parameters('allowSharedKeyAccess')]",
         "allowCrossTenantReplication": false,
         "networkAcls": {
           "copy": [

--- a/main.bicep
+++ b/main.bicep
@@ -4,6 +4,9 @@ param storageAccountName string
 @description('The name of the blob container to create.')
 param containerName string = 'tfstate'
 
+@description('Allow authenticating to the storage account using a shared access key?')
+param allowSharedKeyAccess bool = false
+
 @description('An array of IP addresses or IP ranges that should be allowed to bypass the firewall of the Terraform backend. If empty, the firewall will be disabled.')
 param ipRules array = []
 
@@ -22,7 +25,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
     allowBlobPublicAccess: false
-    allowSharedKeyAccess: false
+    allowSharedKeyAccess: allowSharedKeyAccess
     allowCrossTenantReplication: false
     networkAcls: {
       defaultAction: length(ipRules) == 0 ? 'Allow' : 'Deny'


### PR DESCRIPTION
Set to `true` to allow authenticating to the storage account using shared access key.

Defaults to `false` to increase security and ensure backwards compatability with previous versions of the template.