### PR TITLE
feat!: create resource group

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,10 @@ Azure Resource Manager (ARM) template that creates an Azure Storage account to s
    az account set --name <SUBSCRIPTION_NAME>
    ```
 
-1. Create resource group:
+1. Create a deployment at subscription from the template URI:
 
    ```console
-   az group create --name <RESOURCE_GROUP_NAME> --location <LOCATION>
-   ```
-
-   Requires Azure role `Contributor` at subscription.
-
-1. Create a deployment at resource group from the template URI:
-
-   ```console
-   az deployment group create --name terraform-backend --resource-group <RESOURCE_GROUP_NAME> --template-uri https://raw.githubusercontent.com/equinor/azure-terraform-backend-template/main/azuredeploy.json --parameters storageAccountName=<STORAGE_ACCOUNT_NAME>
+   az deployment group create --name terraform-backend --location northeurope --template-uri https://raw.githubusercontent.com/equinor/azure-terraform-backend-template/main/azuredeploy.json --parameters storageAccountName=<STORAGE_ACCOUNT_NAME>
    ```
 
    Requires Azure role `Owner` at resource group.
@@ -79,6 +71,7 @@ Azure Resource Manager (ARM) template that creates an Azure Storage account to s
 
 | Name | Description | Type | Default |
 | - | - | - | - |
+| `resourceGroupName` | The name of the resource group to create. | `string` | |
 | `storageAccountName` | The name of the storage account to create. | `string` | |
 | `containerName` | The name of the blob container to create. | `string` | `tfstate` |
 | `allowSharedAccessKey` | Allow authenticating to the storage account using a shared access key? | `bool` | `false` |
@@ -94,6 +87,7 @@ When the deployment succeeds, the following output values are automatically retu
 
 | Name | Description | Type |
 | - | - | - |
+| `resourceGroupName` | The name of the resource group that was created. | `string` |
 | `storageAccountName` | The name of the storage account that was created. | `string` |
 | `containerName` | The name of the blob container that was created. | `string` |
 

--- a/main.bicep
+++ b/main.bicep
@@ -1,3 +1,8 @@
+targetScope = 'subscription'
+
+@description('The name of the resource group to create.')
+param resourceGroupName string
+
 @description('The name of the Storage account to create.')
 param storageAccountName string
 
@@ -13,113 +18,21 @@ param ipRules array = []
 @description('An array of object IDs of user, group or service principals that should have access to the Terraform backend.')
 param principalIds array = []
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
-  name: storageAccountName
-  location: resourceGroup().location
-  sku: {
-    name: 'Standard_GRS'
-  }
-  kind: 'StorageV2'
-  properties: {
-    accessTier: 'Hot'
-    supportsHttpsTrafficOnly: true
-    minimumTlsVersion: 'TLS1_2'
-    allowBlobPublicAccess: false
+var location = deployment().location
+
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module storage 'modules/storage.bicep' = {
+  name: 'storage'
+  scope: resourceGroup
+  params: {
+    storageAccountName: storageAccountName
+    containerName: containerName
     allowSharedKeyAccess: allowSharedKeyAccess
-    allowCrossTenantReplication: false
-    networkAcls: {
-      defaultAction: length(ipRules) == 0 ? 'Allow' : 'Deny'
-      virtualNetworkRules: []
-      ipRules: [
-        for ipRule in ipRules: {
-          value: ipRule
-          action: 'Allow'
-        }
-      ]
-    }
-  }
-
-  resource blobService 'blobServices' = {
-    name: 'default'
-    properties: {
-      deleteRetentionPolicy: {
-        allowPermanentDelete: false
-        enabled: true
-        days: 30
-      }
-      containerDeleteRetentionPolicy: {
-        enabled: true
-        days: 30
-      }
-      isVersioningEnabled: true
-      changeFeed: {
-        enabled: true
-      }
-    }
-
-    resource container 'containers' = {
-      name: containerName
-    }
-  }
-
-  resource managementPolicy 'managementPolicies' = {
-    name: 'default'
-    properties: {
-      policy: {
-        rules: [
-          {
-            name: 'Delete old tfstate versions'
-            enabled: true
-            type: 'Lifecycle'
-            definition: {
-              actions: {
-                version: {
-                  delete: {
-                    daysAfterCreationGreaterThan: 30
-                  }
-                }
-              }
-              filters: {
-                blobTypes: [
-                  'blockBlob'
-                ]
-              }
-            }
-          }
-        ]
-      }
-    }
+    ipRules: ipRules
+    principalIds: principalIds
   }
 }
-
-resource roleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-01-preview' existing = {
-  name: 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b' // Storage Blob Data Owner
-  scope: subscription()
-}
-
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for principalId in principalIds: {
-    name: guid(storageAccount.id, principalId, roleDefinition.id)
-    scope: storageAccount
-    properties: {
-      principalId: principalId
-      roleDefinitionId: roleDefinition.id
-    }
-  }
-]
-
-resource lock 'Microsoft.Authorization/locks@2020-05-01' = {
-  name: 'Terraform'
-  scope: storageAccount
-  dependsOn: [storageAccount::blobService, storageAccount::managementPolicy, roleAssignment] // Lock must be created last
-  properties: {
-    level: 'ReadOnly'
-    notes: 'Prevent changes to Terraform backend configuration'
-  }
-}
-
-@description('The name of the Storage account that was created.')
-output storageAccountName string = storageAccount.name
-
-@description('The name of the blob container that was created.')
-output containerName string = storageAccount::blobService::container.name

--- a/modules/storage.bicep
+++ b/modules/storage.bicep
@@ -1,0 +1,125 @@
+@description('The name of the Storage account to create.')
+param storageAccountName string
+
+@description('The name of the blob container to create.')
+param containerName string = 'tfstate'
+
+@description('Allow authenticating to the storage account using a shared access key?')
+param allowSharedKeyAccess bool = false
+
+@description('An array of IP addresses or IP ranges that should be allowed to bypass the firewall of the Terraform backend. If empty, the firewall will be disabled.')
+param ipRules array = []
+
+@description('An array of object IDs of user, group or service principals that should have access to the Terraform backend.')
+param principalIds array = []
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_GRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: allowSharedKeyAccess
+    allowCrossTenantReplication: false
+    networkAcls: {
+      defaultAction: length(ipRules) == 0 ? 'Allow' : 'Deny'
+      virtualNetworkRules: []
+      ipRules: [
+        for ipRule in ipRules: {
+          value: ipRule
+          action: 'Allow'
+        }
+      ]
+    }
+  }
+
+  resource blobService 'blobServices' = {
+    name: 'default'
+    properties: {
+      deleteRetentionPolicy: {
+        allowPermanentDelete: false
+        enabled: true
+        days: 30
+      }
+      containerDeleteRetentionPolicy: {
+        enabled: true
+        days: 30
+      }
+      isVersioningEnabled: true
+      changeFeed: {
+        enabled: true
+      }
+    }
+
+    resource container 'containers' = {
+      name: containerName
+    }
+  }
+
+  resource managementPolicy 'managementPolicies' = {
+    name: 'default'
+    properties: {
+      policy: {
+        rules: [
+          {
+            name: 'Delete old tfstate versions'
+            enabled: true
+            type: 'Lifecycle'
+            definition: {
+              actions: {
+                version: {
+                  delete: {
+                    daysAfterCreationGreaterThan: 30
+                  }
+                }
+              }
+              filters: {
+                blobTypes: [
+                  'blockBlob'
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource roleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-01-preview' existing = {
+  name: 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b' // Storage Blob Data Owner
+  scope: subscription()
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for principalId in principalIds: {
+    name: guid(storageAccount.id, principalId, roleDefinition.id)
+    scope: storageAccount
+    properties: {
+      principalId: principalId
+      roleDefinitionId: roleDefinition.id
+    }
+  }
+]
+
+resource lock 'Microsoft.Authorization/locks@2020-05-01' = {
+  name: 'Terraform'
+  scope: storageAccount
+  dependsOn: [storageAccount::blobService, storageAccount::managementPolicy, roleAssignment] // Lock must be created last
+  properties: {
+    level: 'ReadOnly'
+    notes: 'Prevent changes to Terraform backend configuration'
+  }
+}
+
+@description('The name of the Storage account that was created.')
+output storageAccountName string = storageAccount.name
+
+@description('The name of the blob container that was created.')
+output containerName string = storageAccount::blobService::container.name


### PR DESCRIPTION
Remove the need to explicitly create a resource group before deploying the template.

- Create a module `storage.bicep` that creates Storage resources. This module should be identical to the previous `main.bicep` template,
- Update the `main.bicep` template to first create a resource group, then deploy the `storage.bicep` module at the resource group.

BREAKING CHANGE: add required parameter `resourceGroupName`.